### PR TITLE
fix: ignore `layouts` for `vue/multi-word-component-names`

### DIFF
--- a/.eslintrc.simple.cjs
+++ b/.eslintrc.simple.cjs
@@ -45,4 +45,10 @@ module.exports = {
 			},
 		],
 	},
+	overrides: [
+		{
+			files: ['layouts/*.vue'],
+			rules: { 'vue/multi-word-component-names': 'off' },
+		},
+	]
 };

--- a/.eslintrc.simple.cjs
+++ b/.eslintrc.simple.cjs
@@ -35,7 +35,6 @@ module.exports = {
 					'app',
 					'App',
 					'error',
-					'default',
 					'[...]',
 					'[...slug]',
 					'[...page]',

--- a/.eslintrc.simple.cjs
+++ b/.eslintrc.simple.cjs
@@ -32,9 +32,6 @@ module.exports = {
 			'error',
 			{
 				ignores: [
-					'app',
-					'App',
-					'error',
 					'[...]',
 					'[...slug]',
 					'[...page]',
@@ -46,7 +43,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: ['layouts/*.vue'],
+			files: ['./*.vue', 'layouts/*.vue'],
 			rules: { 'vue/multi-word-component-names': 'off' },
 		},
 	]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@limbo-works/lint-configs",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Package for eslint and prettier configs",
 	"main": "index.cjs",
 	"scripts": {


### PR DESCRIPTION
We often do single-name layout names, which interferes a bit with the `vue/multi-word-component-names`.
So, I've added an override for the `layouts` directory.